### PR TITLE
Early exit when we service an interrupt

### DIFF
--- a/CPU.cpp
+++ b/CPU.cpp
@@ -105,6 +105,7 @@ void CPU::updateInterrupts(short &cycles) {
 						if (isBitSet(enabledReg, bit)) {
 							serviceInterrupt(Interrupts(bit));
 							cycles += 20;
+							return;
 						}
 					}
 				}


### PR DESCRIPTION
Only service the top priority interrupt at a time as otherwise we will only actually service the least priority one when we have multiple interrupt requests at the same time and efectively lost all the other requests (and count the cycles of all the services anyways).